### PR TITLE
Add -r flag for install requirements.txt in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ```
 git clone https://github.com/richzhang/colorization.git
-pip install requirements.txt
+pip install -r requirements.txt
 ```
 
 **Colorize!** This script will colorize an image. The results should match the images in the `imgs_out` folder.


### PR DESCRIPTION
For install dependencies using pip from file,
it is needed to add the -r flag for the install command.
